### PR TITLE
added matters#show

### DIFF
--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -104,3 +104,11 @@ a.button {
     }
   }
 }
+
+.right {
+  text-align: right;
+
+  .button {
+    width: 200px;
+  }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -128,7 +128,7 @@ class ApplicationController < ActionController::Base
       # Create user/account in your application here
       redirect_to ENV["CLIO_MANAGE_SITE_URL"] + "app_integrations_callback"
     else
-      redirect_to "/profile/index"
+      redirect_to "/profile"
     end
   end
 
@@ -155,6 +155,19 @@ class ApplicationController < ActionController::Base
       error_message: message,
       error_info: info
     }
+  end
+
+  def get_manage_token
+    # Ensure we still have the tokens obtained during authentication and authorization.
+    id_token = cookies.encrypted[:id_token]
+    manage_token = cookies.encrypted[:manage_token]
+
+    if id_token.blank? || manage_token.blank?
+      redirect_to root_path
+      return
+    end
+
+    manage_token
   end
 
 end

--- a/app/controllers/matter_controller.rb
+++ b/app/controllers/matter_controller.rb
@@ -3,32 +3,41 @@ require "http"
 class MatterController < ApplicationController
 
   def index
-    # First ensure we still have the tokens obtained during authentication and authorization.
-    id_token = cookies.encrypted[:id_token]
-    manage_token = cookies.encrypted[:manage_token]
-    if id_token.blank? || manage_token.blank?
-      redirect_to root_path
-      return
-    end
-
     # In this example we're getting the firms Matters using Unlimited Cursor Pagination
-    # https://app.clio.com/api/v4/documentation#section/Matters
+    # https://app.clio.com/api/v4/documentation#operation/Matter#index
     # https://app.clio.com/api/v4/documentation#section/Paging/Unlimited-Cursor-Pagination
     params = {
-      fields: "display_number,description,status",
+      fields: "id,display_number,description,status",
       status: "open",
       limit: 10,
       order: "id(asc)"
     }
-    response = HTTP.auth("Bearer " + cookies.encrypted[:manage_token]).get(ENV["CLIO_MANAGE_SITE_URL"] + "api/v4/matters?" + params.to_query)
+    response = HTTP.auth("Bearer " + get_manage_token).get(ENV["CLIO_MANAGE_SITE_URL"] + "api/v4/matters?" + params.to_query)
 
     handle_matters_response(response)
   end
 
   def paginate
     new_page_url = params[:page]
-    response = HTTP.auth("Bearer " + cookies.encrypted[:manage_token]).get(new_page_url)
+    response = HTTP.auth("Bearer " + get_manage_token).get(new_page_url)
     handle_matters_response(response)
+  end
+
+  def show
+    # In this example we're getting all attributes of a single Matter
+    # https://app.clio.com/api/v4/documentation#operation/Matter#show
+    matter_id = params[:id]
+    if matter_id.blank?
+      redirect_to root_path
+      return
+    end
+
+    params = {
+      fields: "id,etag,number,display_number,custom_number,description,status,location,client_reference,client_id,billable,maildrop_address,billing_method,open_date,close_date,pending_date,created_at,updated_at,shared,has_tasks,client,contingency_fee,custom_rate,evergreen_retainer,folder,group,matter_budget,originating_attorney,practice_area,responsible_attorney,statute_of_limitations,user,account_balances,custom_field_values,custom_field_set_associations,relationships,task_template_list_instances"
+    }
+    response = HTTP.auth("Bearer " + get_manage_token).get(ENV["CLIO_MANAGE_SITE_URL"] + "api/v4/matters/" + matter_id + "?" + params.to_query)
+
+    handle_matter_response(response)
   end
 
   private
@@ -37,16 +46,27 @@ class MatterController < ApplicationController
     parsed_response = JSON.parse(response)
 
     if response.code != 200
-      render "application/error", locals: {
-        error_message: "Error getting matters response",
-        error_info: parsed_response["error"]
-      }
+      render_error("Error getting matters response", parsed_response["error"])
+      return
     end
 
-    render "index", layout: "application", locals: {
+    render "index", locals: {
       paging: parsed_response["meta"]["paging"],
       matters: parsed_response["data"]
     }
   end
 
+  def handle_matter_response(response)
+    parsed_response = JSON.parse(response)
+
+    if response.code != 200
+      render_error("Error getting single matter response", parsed_response["error"])
+      return
+    end
+
+    render "show", locals: {
+      matter: parsed_response["data"],
+      back: params[:back] || matter_index_path
+    }
+  end
 end

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -3,30 +3,20 @@ require "http"
 class ProfileController < ApplicationController
 
   def index
-    # First ensure we still have the tokens obtained during authentication and authorization.
-    id_token = cookies.encrypted[:id_token]
-    manage_token = cookies.encrypted[:manage_token]
-    if id_token.blank? || manage_token.blank?
-      redirect_to root_path
-      return
-    end
-
     # Then use the Clio Manage Access Token to make an API call. In this example we're getting some basic profile
     # information from the `api/v4/users/who_am_i` endpoint and displaying it on our profile page.
     params = {
       fields: "id,first_name,last_name,email,phone_number,account_owner"
     }
-    response = HTTP.auth("Bearer " + manage_token).get(ENV["CLIO_MANAGE_SITE_URL"] + "api/v4/users/who_am_i?" + params.to_query)
+    response = HTTP.auth("Bearer " + get_manage_token).get(ENV["CLIO_MANAGE_SITE_URL"] + "api/v4/users/who_am_i?" + params.to_query)
     parsed_response = JSON.parse(response)
 
     if response.code != 200
-      render "application/error", locals: {
-        error_message: "Error getting who_am_i? response",
-        error_info: parsed_response["error"]
-      }
+      render_error("Error getting who_am_i? response", parsed_response["error"])
+      return
     end
 
-    render "index", layout: "application", locals: {
+    render "index", locals: {
       data: parsed_response["data"]
     }
   end

--- a/app/views/matter/index.html.erb
+++ b/app/views/matter/index.html.erb
@@ -20,12 +20,18 @@
           <th>Display Number</th>
           <th>Description</th>
           <th>Status</th>
+          <th></th>
         </tr>
         <% matters.each do |matter| %>
           <tr>
             <td><%= matter["display_number"] %></td>
             <td><%= matter["description"] %></td>
             <td><%= matter["status"] %></td>
+            <td>
+              <a href="<%= matter_path(id: matter["id"], back: request.original_url) %>" class="button">
+                View
+              </a>
+            </td>
           </tr>
         <% end %>
       </table>

--- a/app/views/matter/show.html.erb
+++ b/app/views/matter/show.html.erb
@@ -1,0 +1,51 @@
+<div class="container">
+  <div class="card">
+    <div class="card-header">
+      <img src="/switchboard_logo.svg" />
+      <div class="nav-dropdown">
+        <a class="button">
+          <span class="menu-icon"></span>
+        </a>
+        <div class="nav-dropdown-content">
+          <a href="<%= profile_index_path %>">Profile (tokens, simple API example)</a>
+          <a href="<%= matter_index_path %>">Matters (pagination example)</a>
+          <a href="<%= signout_path %>">Sign Out</a>
+        </div>
+      </div>
+    </div>
+    <div class="card-body">
+      <h1><%= matter["display_number"] %></h1>
+      <table class="data-table">
+        <% matter.without("display_number").select do |attribute_key, value| %>
+        <tr>
+          <th><%= attribute_key %></th>
+          <td>
+            <% if value.is_a?(Hash) %>
+              </br>
+              <% value.each do |sub_attribute_key, sub_value| %>
+                <%= sub_attribute_key %>: <%= sub_value %></br>
+              <% end %>
+              </br>
+            <% elsif value.is_a?(Array) %>
+              </br>
+              <% value.each do |object|  %>
+                <% object.each do |sub_attribute_key, sub_value| %>
+                  <%= sub_attribute_key %>: <%= sub_value %></br>
+                <% end %>
+                </br>
+              <% end %>
+            <% else %>
+              <%= value %>
+            <% end %>
+          </td>
+        </tr>
+        <% end %>
+      </table>
+      <div class="right">
+        <a href="<%= back %>" class="button">
+          Back
+        </a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,8 @@ Rails.application.routes.draw do
     get "signout"
   end
 
-  get "welcome/index"
-  get "profile/index"
-  get "matter/index"
-  get "matter/paginate"
+  resources :welcome, only: [:index]
+  resources :profile, only: [:index]
+  get "/matter/paginate", to: "matter#paginate"
+  resources :matter, only: [:index, :show]
 end


### PR DESCRIPTION
New endpoint for showing a single matter. The matter index page has been updated with show links. Some minor refactoring was included. 

**How do we test it?**
- Run Switchboard 
- Navigate to the matters (pagination) example page
- [x] On the first page of results, click "View" next to a matter, a page should load with the details of that matter 
- [x] Scroll all the way down, click "Back" and it should return you to the first page of matters 
- [x] Navigate to the next page, click "View" next to a matter, a page should load with the details of that matter 
- [x] Scroll all the way down, click "Back" and it should return you to the second page of matters
- [x] While on the show page, the menu at the top right can return you to the matters or profile pages 