### PR TITLE
Implementing Clio SSO in a pop up window

### DIFF
--- a/app/assets/javascripts/welcome.js
+++ b/app/assets/javascripts/welcome.js
@@ -1,0 +1,18 @@
+function receiveMessageFromPopup(event) {
+  if (event.origin !== "http://localhost:3013" || !event.isTrusted) {
+    console.log("You are not worthy, received message from unknown source!");
+  } else {
+    if (event.data === "authentication_successful") {
+      console.log(
+        "Sign in was successful, redirect to the matter page.",
+        event.data
+      );
+      window.location.href = "/matter";
+    } else {
+      console.log("Sign in failed.", event.data);
+    }
+  }
+}
+
+//Listen for message events
+window.addEventListener("message", receiveMessageFromPopup, false);

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -145,8 +145,13 @@ class ApplicationController < ActionController::Base
       # Create user/account in your application here
       redirect_to ENV["CLIO_MANAGE_SITE_URL"] + "app_integrations_callback"
     else
-      redirect_to "/profile"
+      redirect_to "/auth_popup_callback"
     end
+  end
+
+  # Upon succesful callback, we send a message to the main window
+  def auth_popup_callback
+    render plain: "<script>window.opener.postMessage('authentication_successful', 'http://localhost:3013');window.close();</script>", content_type: "text/html"
   end
 
   def signout
@@ -183,5 +188,4 @@ class ApplicationController < ActionController::Base
       redirect_to root_path
     end
   end
-
 end

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -18,7 +18,10 @@
       </form>
     </div>
     <div class="card-footer">
-      <a class="button" tabindex="0" href="<%= authenticate_with_identity_path %>"><img src="clio-logo-white.svg" /> Sign in with Clio</a>
+      <a class="button" tabindex="0" target="popup"
+       onclick="window.open('<%= authenticate_with_identity_path %>','targetWindow','height=600,width=800modal=yes'); return false;">
+        <img src="clio-logo-white.svg" /> Sign in with Clio
+      </a>
     </div>
     <div class="card-footer">
       <p>

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,7 +1,7 @@
 SecureHeaders::Configuration.default do |config|
   config.csp = {
     default_src: %w('none'), # nothing allowed by default
-    script_src: %w('self'),
+    script_src: %w('self' 'unsafe-inline' 'unsafe-eval'),
     connect_src: %w('self'),
     img_src: %w('self' data:),
     font_src: %w('self' data:),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     get "authenticate_with_identity"
     get "identity_callback"
     get "manage_callback"
+    get "auth_popup_callback"
     get "signout"
   end
 


### PR DESCRIPTION
- The "Sign in with Clio" button opens the authentication URL in a popup window.
- When authentication successful, the app instance in the pop up sends a success message to the main window, and closes itself.
- Upon receiving the success message the main window redirect to the Matter page (requires auth).