### PR TITLE
updated the back link to not use a param

### DIFF
--- a/app/controllers/matter_controller.rb
+++ b/app/controllers/matter_controller.rb
@@ -67,8 +67,7 @@ class MatterController < ApplicationController
     end
 
     render "show", locals: {
-      matter: parsed_response["data"],
-      back: params[:back] || matter_index_path
+      matter: parsed_response["data"]
     }
   end
 end

--- a/app/views/matter/index.html.erb
+++ b/app/views/matter/index.html.erb
@@ -28,7 +28,7 @@
             <td><%= matter["description"] %></td>
             <td><%= matter["status"] %></td>
             <td>
-              <a href="<%= matter_path(id: matter["id"], back: request.original_url) %>" class="button">
+              <a href="<%= matter_path(id: matter["id"]) %>" class="button">
                 View
               </a>
             </td>

--- a/app/views/matter/show.html.erb
+++ b/app/views/matter/show.html.erb
@@ -42,9 +42,7 @@
         <% end %>
       </table>
       <div class="right">
-        <a href="<%= back %>" class="button">
-          Back
-        </a>
+        <%= link_to "Back", :back, class: "button" %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Updated the back link so it can no longer be exploited by script injection.

**How do we test this?**
* Run the example app
* Sign in, accept permissions 
* Go to [the matters page](http://localhost:3013/matter)
* Click view next to any matter
- [x] There is no longer a back parameter that can be exploited 
* Scroll down and click back
- [x] You land on page 1
* Go forward at least 1 page
* Click view next to any matter, scroll down and click back
- [x] You land on the page you were just on