### PR TITLE
Provide request body in token HTTP request

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -104,7 +104,7 @@ class ApplicationController < ActionController::Base
     end
 
     # Then we make a request for the Clio Manaage access token.
-    response = HTTP.headers("Content-Type" => "application/x-www-form-urlencoded").post(manage_token_url(params[:code]))
+    response = HTTP.headers("Content-Type" => "application/x-www-form-urlencoded").post(manage_token_url, form: manage_token_body(params[:code]))
     parsed_response = JSON.parse(response.body)
 
     # Make sure to handle any error cases.

--- a/app/helpers/manage_authorization_helper.rb
+++ b/app/helpers/manage_authorization_helper.rb
@@ -11,15 +11,18 @@ module ManageAuthorizationHelper
     ENV["CLIO_MANAGE_SITE_URL"] + "oauth/authorize?" + params.to_query
   end
 
-  def manage_token_url(code)
-    params = {
+  def manage_token_url
+    ENV["CLIO_MANAGE_SITE_URL"] + "oauth/token?"
+  end
+
+  def manage_token_body(code)
+    {
       client_id: ENV["CLIO_MANAGE_CLIENT_ID"],
       client_secret: ENV["CLIO_MANAGE_CLIENT_SECRET"],
       grant_type: "authorization_code",
       code: code,
       redirect_uri: ENV["ROOT_URL"] + "manage_callback"
     }
-    ENV["CLIO_MANAGE_SITE_URL"] + "oauth/token?" + params.to_query
   end
 
   def manage_state_valid?(manage_state)


### PR DESCRIPTION
Provide a request body instead of url params in the HTTP request to exchange an authorization code for an access token, as per the [API guide](https://docs.developers.clio.com/api-docs/authorization/#step-2-exchange-the-authorization-code-for-an-access_token).