### PR TITLE
add example-third-party-application.clio.dev to config.hosts in production.rb

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,8 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  config.hosts << "example-third-party-application.clio.dev"
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 


### PR DESCRIPTION
Rails 6 introduces blocked hosts. In order for our deployed example app to be reachable, we need to add `example-third-party-application.clio.dev` to the config.hosts of production.rb to avoid this error:

<img width="1455" alt="image" src="https://github.com/clio/example-third-party-application/assets/17152058/606a04ae-ce68-474e-8ca4-86c73749b3d7">

