### PR TITLE
Upgrade Dockerfile base image to ruby:3.1.6-bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.6
+FROM ruby:3.1.6-bullseye
 
 RUN apt-get update -qq && apt-get install -y nodejs
 


### PR DESCRIPTION
Updating Docker to use the bullseye version of `Ruby 3.1.6` after reviewing some pipeline failures.